### PR TITLE
Simplify HandlePrepareFunc

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,12 +14,12 @@ go get github.com/akm/slogw@latest
 You can register your handle function like this:
 
 ```golang
-	slogw.Register(func(ctx context.Context, rec slog.Record) *slog.Record {
+	slogw.Register(func(ctx context.Context, rec slog.Record) slog.Record {
 		val, ok := ctx.Value(ctxKey1).(string)
 		if ok {
 			rec.Add("key1", val)
 		}
-		return &rec
+		return rec
 	})
 ```
 

--- a/func_types.go
+++ b/func_types.go
@@ -8,12 +8,12 @@ import (
 type HandleFunc = func(context.Context, slog.Record) error
 type HandleFuncWrapFunc = func(HandleFunc) HandleFunc
 
-type HandlePrepareFunc = func(context.Context, slog.Record) *slog.Record
+type HandlePrepareFunc = func(context.Context, slog.Record) slog.Record
 
 func Prepare(prepare HandlePrepareFunc) HandleFuncWrapFunc {
 	return func(fn HandleFunc) HandleFunc {
 		return func(ctx context.Context, rec slog.Record) error {
-			return fn(ctx, *prepare(ctx, rec))
+			return fn(ctx, prepare(ctx, rec))
 		}
 	}
 }

--- a/wrap_test.go
+++ b/wrap_test.go
@@ -23,12 +23,12 @@ func TestWrapWithRegister(t *testing.T) {
 	}
 
 	defaultFactory = NewFactory()
-	Register(func(ctx context.Context, rec slog.Record) *slog.Record {
+	Register(func(ctx context.Context, rec slog.Record) slog.Record {
 		val, ok := ctx.Value(ctxKey1).(string)
 		if ok {
 			rec.Add("key1", val)
 		}
-		return &rec
+		return rec
 	})
 
 	newLoggerAndBuf := func() (*slog.Logger, *bytes.Buffer) {


### PR DESCRIPTION
[Modify HandlePrepareFunc to return slog.Record instead of *slog.Record](https://github.com/akm/slogw/commit/df4c968e1334bd98fe6e8bd9887c905936361ad3)